### PR TITLE
Drop Python 2 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,13 +20,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "2.7"
           - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
-          - "pypy2.7"
           - "pypy3.7"
 
     steps:
@@ -63,7 +61,6 @@ jobs:
       - name: Report to coveralls
         run: coveralls
         continue-on-error: true
-        if: "matrix.python-version != '2.7' && matrix.python-version != 'pypy2.7'"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_SERVICE_NAME: github

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+* Removed support for Python 2.
 
 
 1.3.0 (2023-05-24)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ environment:
   matrix:
     # https://www.appveyor.com/docs/installed-software#python lists available
     # versions
-    - PYTHON: "C:\\Python27"
     - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python38"
     - PYTHON: "C:\\Python39"

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -46,7 +45,7 @@ setup(
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
     license="GPL v2 or v3",
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*",
+    python_requires=">=3.7",
 
     py_modules=["strace_process_tree"],
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py37,py38,py39,py310,py311,pypy,pypy3
+envlist = py37,py38,py39,py310,py311,pypy3
 
 [testenv]
 deps =


### PR DESCRIPTION
We want to add type annotations and Python 2 does not support them.
And it has been unsupported for a while anyway.
