### PR TITLE
Replace setup.py with pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,17 @@ py-modules = ["strace_process_tree"]
 
 [tool.setuptools.dynamic]
 version = {attr = "strace_process_tree.__version__"}
+
+[tool.isort]
+# from X import (
+#   a,
+#   b,
+# )
+multi_line_output = 3
+include_trailing_comma = true
+lines_after_imports = 2
+reverse_relative = true
+default_section = "THIRDPARTY"
+known_first_party = "strace_process_tree"
+# known_third_party = pytest, ...
+# skip = filename...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,43 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "strace-process-tree"
+authors = [
+    {name = "Marius Gedminas", email = "marius@gedmin.as"},
+]
+description = "Produce a process tree from an strace log"
+readme = "README.rst"
+requires-python = ">=3.7"
+keywords = ["strace", "log", "process", "tree"]
+license = {text = "GPL-2.0-only OR GPL-3.0-only"}
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+]
+dynamic = ["version"]
+
+[project.scripts]
+strace-process-tree = "strace_process_tree:main"
+
+[project.urls]
+Homepage = "https://github.com/mgedmin/strace-process-tree"
+
+[tool.setuptools]
+zip-safe = false
+py-modules = ["strace_process_tree"]
+
+[tool.setuptools.dynamic]
+version = {attr = "strace_process_tree.__version__"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,17 +12,3 @@ create-wheel = yes
 extend-ignore = E501
 # https://pep8.readthedocs.org/en/latest/intro.html#error-codes
 # E501: line too long (82 > 79 characters)
-
-[isort]
-# from X import (
-#   a,
-#   b,
-# )
-multi_line_output = 3
-include_trailing_comma = true
-lines_after_imports = 2
-reverse_relative = true
-default_section = THIRDPARTY
-known_first_party = strace_process_tree
-# known_third_party = pytest, ...
-# skip = filename...

--- a/setup.py
+++ b/setup.py
@@ -1,57 +1,5 @@
 #!/usr/bin/env python
-import ast
-import os
-import re
-
 from setuptools import setup
 
 
-here = os.path.dirname(__file__)
-with open(os.path.join(here, "README.rst")) as f:
-    long_description = f.read()
-
-metadata = {}
-with open(os.path.join(here, "strace_process_tree.py")) as f:
-    rx = re.compile("(__version__|__author__|__url__|__licence__) = (.*)")
-    for line in f:
-        m = rx.match(line)
-        if m:
-            metadata[m.group(1)] = ast.literal_eval(m.group(2))
-version = metadata["__version__"]
-
-setup(
-    name="strace-process-tree",
-    version=version,
-    author="Marius Gedminas",
-    author_email="marius@gedmin.as",
-    url="https://github.com/mgedmin/strace-process-tree",
-    description="Produce a process tree from an strace log",
-    long_description=long_description,
-    long_description_content_type='text/x-rst',
-    keywords="strace log process tree",
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Environment :: Console",
-        "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
-        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy",
-    ],
-    license="GPL v2 or v3",
-    python_requires=">=3.7",
-
-    py_modules=["strace_process_tree"],
-    zip_safe=False,
-    entry_points={
-        "console_scripts": [
-            "strace-process-tree = strace_process_tree:main",
-        ],
-    },
-)
+setup()


### PR DESCRIPTION
The former is deprecated and mypy would complain:

    error: Skipping analyzing "setuptools": module is installed, but missing library stubs or py.typed marker

`pyproject.toml` is also significantly cleaner.

https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
https://packaging.python.org/en/latest/guides/single-sourcing-package-version/
https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html

Also moved [isort config](https://pycqa.github.io/isort/docs/configuration/config_files#pyprojecttoml-preferred-format) there. [Zest](https://github.com/zestsoftware/zest.releaser/issues/412) and [flake8](https://github.com/PyCQA/flake8/issues/234) are currently not supported so they remain in `setup.cfg`. Not sure what tool `bdist_wheel` and `metadata` is for so they remain as well.
