### PR TITLE
Handle missing pending event to avoid crash

### DIFF
--- a/strace_process_tree.py
+++ b/strace_process_tree.py
@@ -187,7 +187,11 @@ def events(stream):
         if event.startswith('<...'):
             m = RESUMED_PREFIX.match(event)
             if m is not None:
-                pending_event, timestamp = pending.pop(pid)
+                pending_data = pending.pop(pid, None)
+                if pending_data is None:
+                    # No pending event found for this PID, skip
+                    continue
+                pending_event, timestamp = pending_data
                 event = pending_event + event[m.end():]
         if event.endswith(UNFINISHED_SUFFIX):
             pending[pid] = (event[:-len(UNFINISHED_SUFFIX)], timestamp)

--- a/tests.py
+++ b/tests.py
@@ -163,6 +163,17 @@ def test_events_result_unavailable():
     ]
 
 
+def test_events_resumed_without_pending():
+    log_lines = [
+        '99999 02:47:49 <... clone resumed>) = 88888',
+        '100 02:47:50 execve("/bin/true", ["/bin/true"], 0x0 /* 0 vars */) = 0',
+    ]
+    result = list(stp.events(log_lines))
+    assert result == [
+        stp.Event(100, 10070.0, 'execve("/bin/true", ["/bin/true"], 0x0 /* 0 vars */) = 0'),
+    ]
+
+
 def test_events_special_pid_format():
     log_lines = [
         '[pid 27369] execve("bin/test", ["bin/test", "-pvc", "-t", "allowhosts.txt"], 0x7fffa04e8ba0 /* 71 vars */) = 0',


### PR DESCRIPTION
I've had multiple `strace` output crash the script due to missing pending events.
I think those can just be skipped.

Eg. on something like
```
1000 1770331447.981546 execve("/bin/bash", ["bash"], 0x7fff /* 10 vars */) = 0
1000 1770331448.000000 clone(child_stack=NULL, flags=CLONE_CHILD_CLEARTID|CLONE_CHILD_SETTID|SIGCHLD) = 1001
1001 1770331448.020000 <... clone resumed>) = 0
1001 1770331448.030000 execve("/bin/ls", ["ls"], 0x7fff /* 10 vars */) = 0
1001 1770331448.500000 +++ exited with 0 +++
1000 1770331448.600000 +++ exited with 0 +++
```